### PR TITLE
Fix failing to run when launched with npx

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Added
   * Support for node 14 was enabled.
+  * Support for handling when run via `npx`.
 * Docs
   * Improve installation instructions and usage instructions.
 * Misc

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ There are multiple methods for installing this tool:
   ```
 * As a global tool ala `npx`:
   ```shell
-  npm exec --package @cyclonedx/cyclonedx-npm --yes -- exit
+  npx @cyclonedx/cyclonedx-npm
   ```
 * As a development dependency of the current projects:
   ```shell
@@ -53,13 +53,9 @@ Depending on the installation method, the following describes the proper usage:
   ```shell
   cyclonedx-npm --help
   ```
-* If installed as a global tool ala `npx`:
+* If installed as a global tool ala `npx` or as a development dependency of the current projects:
   ```shell
-  npm exec -- @cyclonedx/cyclonedx-npm --help
-  ```
-* If installed as a development dependency of the current projects:
-  ```shell
-  npm exec -- @cyclonedx/cyclonedx-npm --help
+  npx cyclonedx-npm --help
   ```
 
 The help page:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     {
       "name": "Jan Kowalleck",
       "email": "jan.kowalleck@gmail.com"
+    },
+    {
+      "name": "Alex Miller",
+      "email": "codex.nz@gmail.com"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
When testing this before adding this to the package scripts I found I was unable to run `cyclonedx-npm`, due to the command it was selecting being an invalid command to spawn a process with:
```
 >  npx cyclonedx-npm
DEBUG | options: {"packageLockOnly":false,"omit":[],"flattenComponents":false,"specVersion":"1.4","outputFormat":"JSON","outputFile":"-","mcType":"application"}
DEBUG | packageFile: /Users/alexmiller/dev/app/package.json
DEBUG | projectDir: /Users/alexmiller/dev/app
DEBUG | lockFile: /Users/alexmiller/dev/app/package-lock.json
INFO  | gather dependency tree ...
DEBUG | npm-ls: run /Users/alexmiller/.asdf/installs/nodejs/16.14.2/.npm/lib/node_modules/npm/bin/npx-cli.js with ["ls","--json","--all","--long"] in /Users/alexmiller/dev/app
WARN  | npm-ls: STDERR
  npm ERR! could not determine executable to run
  
  npm ERR! A complete log of this run can be found in:
  npm ERR!     /Users/alexmiller/.npm/_logs/2022-08-30T23_38_21_054Z-debug-0.log
  
ERROR | npm-ls: errors
  {}
/Users/alexmiller/dev/app/node_modules/@cyclonedx/cyclonedx-npm/dist/builders.js:82
            throw new Error(`npm-ls exited with errors: ${error.errno ?? '???'} ${error.code ?? npmLsReturns.status ?? 'noCode'} ${error.signal ?? npmLsReturns.signal ?? 'noSignal'}`);
            ^

Error: npm-ls exited with errors: ??? 1 noSignal
    at BomBuilder.fetchNpmLs (/Users/alexmiller/dev/app/node_modules/@cyclonedx/cyclonedx-npm/dist/builders.js:82:19)
    at BomBuilder.buildFromLockFile (/Users/alexmiller/dev/app/node_modules/@cyclonedx/cyclonedx-npm/dist/builders.js:43:41)
    at Object.run (/Users/alexmiller/dev/app/node_modules/@cyclonedx/cyclonedx-npm/dist/cli.js:97:19)
    at Object.<anonymous> (/Users/alexmiller/dev/app/node_modules/@cyclonedx/cyclonedx-npm/bin/cyclonedx-npm-cli.js:2:27)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47
```

We can see from this that it's trying to use: `/Users/alexmiller/.asdf/installs/nodejs/16.14.2/.npm/lib/node_modules/npm/bin/npx-cli.js` as provided by using through `npx`. However, this strictly requires the use of `npm`

I have added some simple handling of the case where `npx` is used to run `cyclonedx-npm`.

Running:
```
> npx cyclonedx-npm
DEBUG | options: {"packageLockOnly":false,"omit":[],"flattenComponents":false,"specVersion":"1.4","outputFormat":"JSON","outputFile":"-","mcType":"application"}
DEBUG | packageFile: /Users/alexmiller/dev/app/package.json
DEBUG | projectDir: /Users/alexmiller/dev/app
DEBUG | lockFile: /Users/alexmiller/dev/app/package-lock.json
DEBUG | command: npx-cli.js usage detected, checking for npm-cli.js ...
DEBUG | command: npm-cli.js found
DEBUG | command: /Users/alexmiller/.asdf/installs/nodejs/16.14.2/.npm/lib/node_modules/npm/bin/npm-cli.js
INFO  | gather dependency tree ...
DEBUG | npm-ls: run /Users/alexmiller/.asdf/installs/nodejs/16.14.2/.npm/lib/node_modules/npm/bin/npm-cli.js with ["ls","--json","--all","--long"] in /Users/alexmiller/dev/app
```