### PR TITLE
chore: disable `jest`'s injectGlobals

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -182,7 +182,7 @@ module.exports = {
   testMatch: [
     //   "**/__tests__/**/*.[jt]s?(x)",
     '**/?(*.)+(spec|test).js'
-  ]
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [
@@ -218,4 +218,8 @@ module.exports = {
 
   // Whether to use watchman for file crawling
   // watchman: true,
+
+  // disable auto-injecting of globals like `expect`, `describe`, `test`, `it`, ...
+  // they are to be imported manually
+  injectGlobals: false
 }


### PR DESCRIPTION
IDE and static code analysis tools failed to detect the globals jest injected,
so i imported them anyway.

now lets disable the injection as a whole.