### PR TITLE
fix: explicit allow engine `npm@10`

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "type": "commonjs",
   "engines": {
     "node": ">=14",
-    "npm": "6 - 9"
+    "npm": "6 - 10"
   },
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
#974 introduced support for npm 10, but package.json engines field was left with just npm 6 - 9. This tiny PR updates the engines field to npm 6 - 10, so npm 10 can be used without `--ignore-engines` flag.

This PR doesn't introduce any functional changes.