### PR TITLE
fix: excplicitely require direct dependency `packageurl-js`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * Added direct dependency `packageurl-js` as such (via [#1122])
+
+[#1122]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/1122
+
 ## 1.14.2 - 2023-11-06
 
 * Fixed

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@cyclonedx/cyclonedx-library": "^6.1.0",
     "commander": "^10.0.0",
     "normalize-package-data": "^3||^4||^5||^6",
+    "packageurl-js": "^1.2.1",
     "xmlbuilder2": "^3.0.2"
   },
   "devDependencies": {

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node20_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node20_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node20_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node20_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node20_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm10_node20_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node14_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node14_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node14_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node16_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node16_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node16_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node19_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node19_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node19_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node19_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node19_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm7_node19_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node14_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node14_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node14_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node16_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node16_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node16_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node19_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node19_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node19_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node19_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node19_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm8_node19_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node16_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node16_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node16_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node19_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node19_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node19_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node19_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node19_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/bare/package-with-build-id_npm9_node19_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node20_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node20_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node20_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node20_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node20_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm10_node20_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node14_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node14_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node14_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node16_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node16_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node16_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node19_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node19_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node19_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node19_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node19_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm7_node19_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node14_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node14_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node14_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node14_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node14_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node14_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node16_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node16_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node16_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node19_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node19_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node19_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node19_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node19_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm8_node19_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node16_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node16_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node16_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node16_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node16_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node16_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node18_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node18_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node18_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node18_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node18_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node18_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node19_macos-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node19_macos-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node19_ubuntu-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node19_ubuntu-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",

--- a/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node19_windows-latest.snap.json
+++ b/tests/_data/sbom_demo-results/flatten-components/package-with-build-id_npm9_node19_windows-latest.snap.json
@@ -60,7 +60,7 @@
       "version": "1.0.0-123+456",
       "bom-ref": "demo-package-with-build-id@1.0.0-123+456",
       "description": "demo: package-with-build-id -- show how buildID in the version looks like",
-      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123%2B456",
+      "purl": "pkg:npm/demo-package-with-build-id@1.0.0-123+456",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues/551",


### PR DESCRIPTION
`packageurl-js` is a transitive dependency, that is true.
but it is also a direct dependency, see  https://github.com/CycloneDX/cyclonedx-node-npm/blob/e22909833c59af038882c0a6f6d555c49bb08492/src/builders.ts#L23

Therefore, it is directly required, now