### PR TITLE
docs: add CycloneDX 1.6 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,27 +74,39 @@ Usage: cyclonedx-npm [options] [--] [<package-manifest>]
 Create CycloneDX Software Bill of Materials (SBOM) from Node.js NPM projects.
 
 Arguments:
-  <package-manifest>        Path to project's manifest file. (default: "package.json" file in current working directory)
+  <package-manifest>        Path to project's manifest file.
+                            (default: "package.json" file in current working directory)
 
 Options:
   --ignore-npm-errors       Whether to ignore errors of NPM.
-                            This might be used, if "npm install" was run with "--force" or "--legacy-peer-deps". (default: false)
+                            This might be used, if "npm install" was run with "--force" or "--legacy-peer-deps".
+                            (default: false)
   --package-lock-only       Whether to only use the lock file, ignoring "node_modules".
-                            This means the output will be based only on the few details in and the tree described by the "npm-shrinkwrap.json" or "package-lock.json", rather than the contents of "node_modules" directory. (default: false)
-  --omit <type...>          Dependency types to omit from the installation tree.(can be set multiple times) (choices: "dev", "optional", "peer", default: "dev" if the NODE_ENV environment variable is set to "production", otherwise empty)
+                            This means the output will be based only on the few details in and the tree described by the "npm-shrinkwrap.json" or "package-lock.json", rather than the contents of "node_modules" directory.
+                            (default: false)
+  --omit <type...>          Dependency types to omit from the installation tree.
+                            (can be set multiple times)
+                            (choices: "dev", "optional", "peer", default: "dev" if the NODE_ENV environment variable is set to "production", otherwise empty)
   --flatten-components      Whether to flatten the components.
-                            This means the actual nesting of node packages is not represented in the SBOM result. (default: false)
+                            This means the actual nesting of node packages is not represented in the SBOM result.
+                            (default: false)
   --short-PURLs             Omit all qualifiers from PackageURLs.
-                            This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings. (default: false)
-  --spec-version <version>  Which version of CycloneDX spec to use. (choices: "1.2", "1.3", "1.4", "1.5", "1.6", default: "1.4")
+                            This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
+                            (default: false)
+  --spec-version <version>  Which version of CycloneDX spec to use.
+                            (choices: "1.2", "1.3", "1.4", "1.5", "1.6", default: "1.4")
   --output-reproducible     Whether to go the extra mile and make the output reproducible.
-                            This requires more resources, and might result in loss of time- and random-based-values. (env: BOM_REPRODUCIBLE)
-  --output-format <format>  Which output format to use. (choices: "JSON", "XML", default: "JSON")
+                            This requires more resources, and might result in loss of time- and random-based-values.
+                            (env: BOM_REPRODUCIBLE)
+  --output-format <format>  Which output format to use.
+                            (choices: "JSON", "XML", default: "JSON")
   --output-file <file>      Path to the output file.
-                            Set to "-" to write to STDOUT. (default: write to STDOUT)
+                            Set to "-" to write to STDOUT.
+                            (default: write to STDOUT)
   --validate                Validate resulting BOM before outputting. Validation is skipped, if requirements not met. See the README.
   --no-validate             Disable validation of resulting BOM.
-  --mc-type <type>          Type of the main component. (choices: "application", "firmware", "library", default: "application")
+  --mc-type <type>          Type of the main component.
+                            (choices: "application", "firmware", "library", default: "application")
   -v, --verbose             Increase the verbosity of messages. Use multiple times to increase the verbosity even more.
   -V, --version             output the version number
   -h, --help                display help for command

--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ Options:
   --output-file <file>      Path to the output file.
                             Set to "-" to write to STDOUT.
                             (default: write to STDOUT)
-  --validate                Validate resulting BOM before outputting. Validation is skipped, if requirements not met. See the README.
+  --validate                Validate resulting BOM before outputting.
+                            Validation is skipped, if requirements not met. See the README.
   --no-validate             Disable validation of resulting BOM.
   --mc-type <type>          Type of the main component.
                             (choices: "application", "firmware", "library", default: "application")
-  -v, --verbose             Increase the verbosity of messages. Use multiple times to increase the verbosity even more.
+  -v, --verbose             Increase the verbosity of messages.
+                            Use multiple times to increase the verbosity even more.
   -V, --version             output the version number
   -h, --help                display help for command
 ```

--- a/README.md
+++ b/README.md
@@ -74,42 +74,28 @@ Usage: cyclonedx-npm [options] [--] [<package-manifest>]
 Create CycloneDX Software Bill of Materials (SBOM) from Node.js NPM projects.
 
 Arguments:
-  <package-manifest>        Path to project's manifest file.
-                            (default: "package.json" file in current working directory)
+  <package-manifest>        Path to project's manifest file. (default: "package.json" file in current working directory)
 
 Options:
   --ignore-npm-errors       Whether to ignore errors of NPM.
-                            This might be used, if "npm install" was run with "--force" or "--legacy-peer-deps".
-                            (default: false)
+                            This might be used, if "npm install" was run with "--force" or "--legacy-peer-deps". (default: false)
   --package-lock-only       Whether to only use the lock file, ignoring "node_modules".
-                            This means the output will be based only on the few details in and the tree described by the "npm-shrinkwrap.json" or "package-lock.json", rather than the contents of "node_modules" directory.
-                            (default: false)
-  --omit <type...>          Dependency types to omit from the installation tree.
-                            (can be set multiple times)
-                            (choices: "dev", "optional", "peer", default: "dev" if the NODE_ENV environment variable is set to "production", otherwise empty)
+                            This means the output will be based only on the few details in and the tree described by the "npm-shrinkwrap.json" or "package-lock.json", rather than the contents of "node_modules" directory. (default: false)
+  --omit <type...>          Dependency types to omit from the installation tree.(can be set multiple times) (choices: "dev", "optional", "peer", default: "dev" if the NODE_ENV environment variable is set to "production", otherwise empty)
   --flatten-components      Whether to flatten the components.
-                            This means the actual nesting of node packages is not represented in the SBOM result.
-                            (default: false)
+                            This means the actual nesting of node packages is not represented in the SBOM result. (default: false)
   --short-PURLs             Omit all qualifiers from PackageURLs.
-                            This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
-                            (default: false)
-  --spec-version <version>  Which version of CycloneDX spec to use.
-                            (choices: "1.2", "1.3", "1.4", "1.5", default: "1.4")
+                            This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings. (default: false)
+  --spec-version <version>  Which version of CycloneDX spec to use. (choices: "1.2", "1.3", "1.4", "1.5", "1.6", default: "1.4")
   --output-reproducible     Whether to go the extra mile and make the output reproducible.
-                            This requires more resources, and might result in loss of time- and random-based-values.
-                            (env: BOM_REPRODUCIBLE)
-  --output-format <format>  Which output format to use.
-                            (choices: "JSON", "XML", default: "JSON")
+                            This requires more resources, and might result in loss of time- and random-based-values. (env: BOM_REPRODUCIBLE)
+  --output-format <format>  Which output format to use. (choices: "JSON", "XML", default: "JSON")
   --output-file <file>      Path to the output file.
-                            Set to "-" to write to STDOUT.
-                            (default: write to STDOUT)
-  --validate                Validate resulting BOM before outputting. Validation is skipped, if requirements not met.
-                            (default: true)
+                            Set to "-" to write to STDOUT. (default: write to STDOUT)
+  --validate                Validate resulting BOM before outputting. Validation is skipped, if requirements not met. See the README.
   --no-validate             Disable validation of resulting BOM.
-  --mc-type <type>          Type of the main component.
-                            (choices: "application", "firmware", "library", default: "application")
-  -v, --verbose             Increase the verbosity of messages.
-                            Use multiple times to increase the verbosity even more.
+  --mc-type <type>          Type of the main component. (choices: "application", "firmware", "library", default: "application")
+  -v, --verbose             Increase the verbosity of messages. Use multiple times to increase the verbosity even more.
   -V, --version             output the version number
   -h, --help                display help for command
 ```


### PR DESCRIPTION
Adjusted to the output of --help in version 1.16.2

This especially makes clear, that version 1.6 of the CycloneDX spec is actually supported.