### PR TITLE
tests: tests are less noisy

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "exports": "./dist/index.js",
   "scripts": {
     "prepublish": "npm run build",
-    "prepublishOnly": "run-s -lc build test",
+    "prepublishOnly": "run-s -lc build test:jest",
     "lint": "tsc --noEmit",
     "prebuild": "node -r fs -e 'fs.rmSync(`dist`,{recursive:true,force:true})'",
     "build": "tsc -b ./tsconfig.json",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -204,7 +204,7 @@ export async function run (process: NodeJS.Process): Promise<number> {
   program.parse(process.argv)
 
   const options: CommandOptions = program.opts()
-  const myConsole = makeConsoleLogger(options.verbose)
+  const myConsole = makeConsoleLogger(process, options.verbose)
   myConsole.debug('DEBUG | options: %j', options)
 
   const packageFile = resolve(process.cwd(), program.args[0] ?? 'package.json')

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -21,7 +21,7 @@ function noop (): void {
   // do nothing
 }
 
-export function makeConsoleLogger (level: number): Console {
+export function makeConsoleLogger (process: NodeJS.Process, level: number): Console {
   // all output shall be bound to stdError - stdOut is for result output only
   const myConsole = new console.Console(process.stderr, process.stderr)
 

--- a/tests/integration/synthetics/cli.run.test.js
+++ b/tests/integration/synthetics/cli.run.test.js
@@ -248,7 +248,6 @@ describe('cli.run()', () => {
     const expectedExitCode = 1 + Math.floor(254 * Math.random())
 
     const { res, outFile, errFile } = runCLI([
-      'dummy_process',
       '-vvv',
       '--ignore-npm-errors',
       '--output-reproducible',

--- a/tests/integration/synthetics/cli.run.test.js
+++ b/tests/integration/synthetics/cli.run.test.js
@@ -217,7 +217,7 @@ describe('cli.run()', () => {
         })
 
         try {
-          await res
+          expect(res).resolves.toBe(0)
         } catch (err) {
           process.stderr.write(readFileSync(errFile))
           throw err
@@ -271,7 +271,7 @@ describe('cli.run()', () => {
     })
 
     try {
-      await res
+      expect(res).resolves.toBe(0)
     } catch (err) {
       process.stderr.write(readFileSync(errFile))
       throw err
@@ -333,7 +333,7 @@ describe('cli.run()', () => {
       })
 
       try {
-        await res
+        expect(res).resolves.toBe(0)
       } catch (err) {
         process.stderr.write(readFileSync(errFile))
         throw err

--- a/tests/integration/synthetics/cli.run.test.js
+++ b/tests/integration/synthetics/cli.run.test.js
@@ -26,7 +26,7 @@ const { describe, expect, test } = require('@jest/globals')
 const { index: indexNpmLsDemoData } = require('../../_data/npm-ls_demo-results')
 const { version: thisVersion } = require('../../../package.json')
 
-const projectRootPath = join(__dirname, '..', '..', '..')
+// const projectRootPath = join(__dirname, '..', '..', '..')
 const projectTestRootPath = join(__dirname, '..', '..')
 
 // const binWrapper = join(projectRootPath, 'bin', 'cyclonedx-npm-cli.js')

--- a/tests/integration/synthetics/cli.run.test.js
+++ b/tests/integration/synthetics/cli.run.test.js
@@ -217,7 +217,7 @@ describe('cli.run()', () => {
         })
 
         try {
-          expect(res).resolves.toBe(0)
+          await expect(res).resolves.toBe(0)
         } catch (err) {
           process.stderr.write(readFileSync(errFile))
           throw err
@@ -271,7 +271,7 @@ describe('cli.run()', () => {
     })
 
     try {
-      expect(res).resolves.toBe(0)
+      await expect(res).resolves.toBe(0)
     } catch (err) {
       process.stderr.write(readFileSync(errFile))
       throw err
@@ -333,7 +333,7 @@ describe('cli.run()', () => {
       })
 
       try {
-        expect(res).resolves.toBe(0)
+        await expect(res).resolves.toBe(0)
       } catch (err) {
         process.stderr.write(readFileSync(errFile))
         throw err


### PR DESCRIPTION
tests polluted the edxErr. this was by mistake, which was fixed, now.
in addition, the release tests were stripped to the needed, which might speed things up 