### PR TITLE
feat!: CLI option `spec-version` defaults to `1.6`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 <!-- unreleased changes go here -->
 
 * BREAKING changes
+  * default value for CLI option `--spec-version` is `1.6` now, was `1.4` ([#1173] via [#]) 
   * Emit `.metadata.tools` as components ([#1233] via [#1235])  
     This affects only CycloneDX spec-version 1.5 and later.
   * Emitted `.purl` values might be partially url-encoded (via [#1235])  
@@ -16,10 +17,12 @@ All notable changes to this project will be documented in this file.
 * Misc
   * Raised dependency `@cyclonedx/cyclonedx-library@^7.0.0`, was `@^6.11.0` (via [#1235])
 
+[#1173]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/1173
 [#1233]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/1233
 [#1235]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/1235
 [#1241]: https://github.com/CycloneDX/cyclonedx-node-npm/issues/1241
 [#1242]: https://github.com/CycloneDX/cyclonedx-node-npm/pull/1242
+[#]: 
 
 ## 1.20.0 -- 2025-01-13
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Options:
                             This causes information loss in trade-off shorter PURLs, which might improve ingesting these strings.
                             (default: false)
   --spec-version <version>  Which version of CycloneDX spec to use.
-                            (choices: "1.2", "1.3", "1.4", "1.5", "1.6", default: "1.4")
+                            (choices: "1.2", "1.3", "1.4", "1.5", "1.6", default: "1.6")
   --output-reproducible     Whether to go the extra mile and make the output reproducible.
                             This requires more resources, and might result in loss of time- and random-based-values.
                             (env: BOM_REPRODUCIBLE)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -112,7 +112,7 @@ function makeCommand (process: NodeJS.Process): Command {
     ).choices(
       Object.keys(Spec.SpecVersionDict).sort()
     ).default(
-      Spec.Version.v1dot4
+      Spec.Version.v1dot6
     )
   ).addOption(
     new Option(


### PR DESCRIPTION
fixes #1173