### PR TITLE
chore: QA tool to detect missing dependencies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -75,7 +75,7 @@ jobs:
       - name: setup tools
         run: |
           echo "::group::install code-style deps"
-          npm run -- dev-setup:code-style --ignore-scripts --loglevel=silly
+          npm run -- dev-setup:tools:code-style --ignore-scripts --loglevel=silly
           echo "::endgroup::"
       - name: make reports dir
         run: mkdir -p "$REPORTS_DIR"
@@ -98,6 +98,34 @@ jobs:
           name: ${{ env.STANDARD_REPORTS_ARTIFACT }}
           path: ${{ env.REPORTS_DIR }}
           if-no-files-found: error
+
+  test-dependencies:
+    name: test dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
+        # see https://github.com/actions/setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_ACTIVE_LTS }}
+          # cache: "npm"
+          # cache-dependency-path: "**/package-lock.json"
+      - name: setup project
+        run: |
+          npm install --ignore-scripts --loglevel=silly
+      - name: setup tools
+        run: |
+          echo "::group::install test-dependencies deps"
+          npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
+          echo "::endgroup::"
+      - name: make reports dir
+        run: mkdir -p "$REPORTS_DIR"
+      - name: test
+        run: npm run -- test:dependencies -q
 
   test-jest:
     needs: [ 'build' ]

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -115,15 +115,9 @@ jobs:
           # cache: "npm"
           # cache-dependency-path: "**/package-lock.json"
       - name: setup project
-        run: |
-          npm install --ignore-scripts --loglevel=silly
+        run: npm install --ignore-scripts --loglevel=silly
       - name: setup tools
-        run: |
-          echo "::group::install test-dependencies deps"
-          npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
-          echo "::endgroup::"
-      - name: make reports dir
-        run: mkdir -p "$REPORTS_DIR"
+        run: npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
       - name: test
         run: npm run -- test:dependencies -q
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -119,7 +119,7 @@ jobs:
       - name: setup tools
         run: npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
       - name: test
-        run: npm run -- test:dependencies -q
+        run: npm run -- test:dependencies -d
 
   test-jest:
     needs: [ 'build' ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_ACTIVE_LTS }}
-      - name: install build tools
-        run: npm i --ignore-scripts
+      - name: setup project
+        run: |
+          npm install --ignore-scripts --include=optional --loglevel=silly
+      - name: install tools
+        run: >
+          echo "::group::install code-style deps"
+          npm run -- dev-setup:tools:code-style --ignore-scripts --loglevel=silly
+          echo "::endgroup::"
+          echo "::group::install test-dependencies deps"
+          npm run -- dev-setup:tools:test-dependencies --ignore-scripts --loglevel=silly
+          echo "::endgroup::"
       # no explicit npm build. if a build is required, it should be configured as prepublish/prepublishOnly script of npm.
       - name: login to NPMJS
         run: npm config set "//registry.npmjs.org/:_authToken=$NPMJS_AUTH_TOKEN"

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema-jsonc.json",
+  "entry": [
+    "src/cli.ts!",
+    "bin/**!"
+  ],
+  "project": [
+    "src/**!",
+    "tests/**",
+    "!tests/_data/dummy_projects/**",
+    "!tests/_data/*-results/**"
+  ],
+  "ignore": [
+    "tools/**"
+  ]
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -12,5 +12,9 @@
   ],
   "ignore": [
     "tools/**"
+  ],
+  "ignoreDependencies": [
+    // needed to force the installation of the optional dependency of a 3rd party package:
+    "xmlbuilder2"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
   "exports": "./index.js",
   "scripts": {
     "dev-setup": "npm i && run-p --aggregate-output -lc dev-setup:\\*",
-    "dev-setup:code-style": "npm --prefix tools/code-style install",
+    "dev-setup:tools": "run-p --aggregate-output -lc dev-setup:tools:\\*",
+    "dev-setup:tools:code-style": "npm --prefix tools/code-style install",
+    "dev-setup:tools:test-dependencies": "npm --prefix tools/test-dependencies install",
     "prepublish": "npm run build",
     "prepublishOnly": "run-s -lc build setup-tests test:jest",
     "lint": "tsc --noEmit",
@@ -116,6 +118,7 @@
     "test": "run-p --aggregate-output -lc test:\\*",
     "test:jest": "c8 jest",
     "test:standard": "npm --prefix tools/code-style exec -- eslint .",
+    "test:dependencies": "npm --prefix tools/test-dependencies exec -- knip --include dependencies,unlisted,unresolved --production",
     "dogfooding:npx": "npx .",
     "dogfooding:npm-exec": "npm exec .",
     "dogfooding:direct": "node -- bin/cyclonedx-npm-cli.js"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "dev-setup:tools:code-style": "npm --prefix tools/code-style install",
     "dev-setup:tools:test-dependencies": "npm --prefix tools/test-dependencies install",
     "prepublish": "npm run build",
-    "prepublishOnly": "run-s -lc build setup-tests test:jest",
+    "prepublishOnly": "run-s -lc build setup-tests test",
     "lint": "tsc --noEmit",
     "prebuild": "node -r fs -e 'fs.rmSync(`dist`,{recursive:true,force:true})'",
     "build": "tsc -b ./tsconfig.json",

--- a/tools/test-dependencies/.gitignore
+++ b/tools/test-dependencies/.gitignore
@@ -1,0 +1,4 @@
+*
+!/.gitignore
+!/package.json
+!/.npmrc

--- a/tools/test-dependencies/.npmrc
+++ b/tools/test-dependencies/.npmrc
@@ -1,0 +1,5 @@
+; see the docs: https://docs.npmjs.com/cli/v9/using-npm/config
+
+package-lock=false
+engine-strict=true
+omit=peer # don't install them automatically; we take cate of them!

--- a/tools/test-dependencies/package.json
+++ b/tools/test-dependencies/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "@cyclonedx/cyclonedx-javascript-library/tools/test-dependencies",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20.18"
+  },
+  "dependencies": {
+    "knip": "5.61.3"
+  }
+}

--- a/tools/test-dependencies/package.json
+++ b/tools/test-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@cyclonedx/cyclonedx-javascript-library/tools/test-dependencies",
+  "name": "@cyclonedx/cyclonedx-webpack-plugin/tools/test-dependencies",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.18"


### PR DESCRIPTION
use `knip` to test for missing dependencies.
since the `import/no-extraneous-dependencies` eslint rule is not working.


TODO / DONE
- [x] add tool
- [x] configure tool
- [x] add GH workflow