### PR TITLE
chore: package-manager-cache: false

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,10 +38,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_ACTIVE_LTS }}
-          # cache: 'npm'
+          package-manager-cache: false
       - name: setup subject
         run: npm i --ignore-scripts --loglevel=silly
       - name: build
@@ -64,11 +64,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_ACTIVE_LTS }}
-          # cache: "npm"
-          # cache-dependency-path: "**/package-lock.json"
+          package-manager-cache: false
       - name: setup project
         run: |
           npm install --ignore-scripts --loglevel=silly
@@ -109,11 +108,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_ACTIVE_LTS }}
-          # cache: "npm"
-          # cache-dependency-path: "**/package-lock.json"
+          package-manager-cache: false
       - name: setup project
         run: npm install --ignore-scripts --loglevel=silly
       - name: setup tools
@@ -146,10 +144,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Setup Node.js ${{ matrix.node-version }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          # cache: 'npm'
+          package-manager-cache: false
       - name: npm version
         run: npm --version
       - name: setup subject
@@ -225,10 +223,10 @@ jobs:
       - run: mkdir -p ${{ env.REPORTS_DIR }}
       - name: Setup Node.js ${{ matrix.node-version }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version || env.NODE_ACTIVE_LTS }}
-          # cache: 'npm'
+          package-manager-cache: false
       - name: setup npm ${{ matrix.npm-version }}
         run: |
           npm i -g npm@${{ matrix.npm-version }}

--- a/.github/workflows/npm-ls_demo-results.yml
+++ b/.github/workflows/npm-ls_demo-results.yml
@@ -86,10 +86,11 @@ jobs:
         shell: bash # don't want to write tht code twice, windows and unix-like
       - name: Setup Node.js ${{ matrix.node-version }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
+          package-manager-cache: false
       - name: up-/down-grade npm to ${{ matrix.npm-version }}
         run: npm i -g 'npm@${{ matrix.npm-version }}'
       - name: report versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,10 @@ jobs:
           git config --local user.name "${GITHUB_ACTOR}"
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_ACTIVE_LTS }}
+          package-manager-cache: false
       ## ! no npm build at the moment
       - name: bump VERSION
         id: bump
@@ -99,9 +100,10 @@ jobs:
           ref: ${{ needs.bump.outputs.version }}
       - name: Setup Node.js ${{ env.NODE_ACTIVE_LTS }}
         # see https://github.com/actions/setup-node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_ACTIVE_LTS }}
+          package-manager-cache: false
       - name: setup project
         run: |
           npm install --ignore-scripts --include=optional --loglevel=silly


### PR DESCRIPTION
caused by complete fuckup of the https://github.com/actions/setup-node authors.
we dont want unexpected caching. 
we dont have a lockfile for a reason -- we want the latest versions, always. 